### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>hmcts/.github//renovate/automerge-all",
+    "local>hmcts/.github:renovate-config"
   ]
 }

--- a/tf-app-insights-alerts.tf
+++ b/tf-app-insights-alerts.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_action_group" "appinsights" {
 resource "azurerm_monitor_metric_alert" "metric_alert_exceptions" {
   name                = "exceptions_alert"
   resource_group_name = azurerm_resource_group.rg.name
-  scopes              = [azurerm_application_insights.appinsights.id]
+  scopes              = [module.application_insights.app_id]
   description         = "Alert will be triggered when Exceptions are more than 2 per 5 mins"
   tags                = var.common_tags
 

--- a/tf-app-insights-alerts.tf
+++ b/tf-app-insights-alerts.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_action_group" "appinsights" {
 resource "azurerm_monitor_metric_alert" "metric_alert_exceptions" {
   name                = "exceptions_alert"
   resource_group_name = azurerm_resource_group.rg.name
-  scopes              = [module.application_insights.app_id]
+  scopes              = [module.application_insights.id]
   description         = "Alert will be triggered when Exceptions are more than 2 per 5 mins"
   tags                = var.common_tags
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.